### PR TITLE
Fix rollbar errors

### DIFF
--- a/lib/assets/styles.css
+++ b/lib/assets/styles.css
@@ -74,6 +74,11 @@ html, body {
   margin-top: 0.33em;
 }
 
+.popular-patterns .pattern .parameter-name,
+.popular-patterns .pattern .keyword-arguments .default-value {
+  color: color(var(--foreground) blend(var(--background) 80%));
+}
+
 .popular-patterns .pattern .keyword-arguments .parameter-name {
   color: var(--orangish);
   font-style: italic;

--- a/lib/deferred.py
+++ b/lib/deferred.py
@@ -78,8 +78,7 @@ class Consumer:
             except Empty:
                 time.sleep(0.01)
             except Exception as ex:
-                if not getattr(ex, 'ignore', False):
-                    reporter.send_rollbar_exc(sys.exc_info())
+                reporter.send_rollbar_exc(sys.exc_info())
                 logger.debug('caught {}: {}'
                              .format(ex.__class__.__name__, str(ex)))
 

--- a/lib/handlers.py
+++ b/lib/handlers.py
@@ -7,7 +7,7 @@ import json
 import sys
 import os
 from http.client import CannotSendRequest
-from jinja2 import Template
+from ..vendor.jinja2 import Template
 from os.path import realpath
 from threading import Lock
 from urllib.parse import quote

--- a/lib/handlers.py
+++ b/lib/handlers.py
@@ -7,7 +7,11 @@ import json
 import sys
 import os
 from http.client import CannotSendRequest
+
+# Use the vendored version explicitly in case the user has an older version
+# of jinja2 in his environment (See: http://bit.ly/2Ozn2QB)
 from ..vendor.jinja2 import Template
+
 from os.path import realpath
 from threading import Lock
 from urllib.parse import quote

--- a/lib/requests.py
+++ b/lib/requests.py
@@ -7,6 +7,12 @@ _KITED_HOST = 'localhost'
 _KITED_PORT = 46624
 _conns = [None]*4
 
+_RESET_EXCEPTIONS = (
+    ConnectionRefusedError,
+    ConnectionResetError,
+    OSError,
+    CannotSendRequest,
+)
 
 def kited_get(path):
     """Makes a GET request to a Kite endpoint specified by the `path`
@@ -19,8 +25,7 @@ def kited_get(path):
     except timeout as ex:
         ex.ignore = True
         raise ex
-    except (ConnectionRefusedError, ConnectionResetError,
-            CannotSendRequest) as ex:
+    except _RESET_EXCEPTIONS as ex:
         _reset_connection(idx)
         ex.ignore = True
         raise ex
@@ -43,8 +48,7 @@ def kited_post(path, data=None):
     except timeout as ex:
         ex.ignore = True
         raise ex
-    except (ConnectionRefusedError, ConnectionResetError,
-            CannotSendRequest) as ex:
+    except _RESET_EXCEPTIONS as ex:
         _reset_connection(idx)
         ex.ignore = True
         raise ex

--- a/lib/requests.py
+++ b/lib/requests.py
@@ -22,12 +22,8 @@ def kited_get(path):
 
     try:
         conn.request('GET', path, headers={'Connection': 'keep-alive'})
-    except timeout as ex:
-        ex.ignore = True
-        raise ex
     except _RESET_EXCEPTIONS as ex:
         _reset_connection(idx)
-        ex.ignore = True
         raise ex
     else:
         resp = conn.getresponse()
@@ -45,12 +41,8 @@ def kited_post(path, data=None):
     try:
         conn.request('POST', path, headers={'Connection': 'keep-alive'},
                      body=(json.dumps(data) if data is not None else None))
-    except timeout as ex:
-        ex.ignore = True
-        raise ex
     except _RESET_EXCEPTIONS as ex:
         _reset_connection(idx)
-        ex.ignore = True
         raise ex
     else:
         resp = conn.getresponse()


### PR DESCRIPTION
• Fixes https://rollbar.com/Kite/sublime-prod/items/25/ by explicitly using the vendored version of `jinja2`
• Handles https://rollbar.com/Kite/sublime-prod/items/38/ by adding `OSError` to the collection or error types on which we reset connections
• Some styling changes to popular patterns
• Removes the ignore exception since it didn't seem to be working - Will figure out how to handle this in a later PR