### PR TITLE
Fix jinja2 path

### DIFF
--- a/lib/handlers.py
+++ b/lib/handlers.py
@@ -8,13 +8,6 @@ import sys
 import os
 from http.client import CannotSendRequest
 
-# Use the vendored version explicitly in case the user has an older version
-# of jinja2 in his environment e.g. GitGutter uses v2.8, which is outdated.
-rm_mods = [m for m in sys.modules.keys() if m.startswith('jinja2')]
-for m in rm_mods:
-    del sys.modules[m]
-from ..vendor.jinja2 import Template
-
 from os.path import realpath
 from threading import Lock
 from urllib.parse import quote
@@ -22,6 +15,24 @@ from urllib.parse import quote
 from ..lib import deferred, keymap, link_opener, logger, settings, requests
 from ..lib.file_system import path_for_url
 from ..setup import is_development, os_version
+
+# Use the vendored version explicitly in case the user has an older version
+# of jinja2 in his environment e.g. GitGutter uses v2.8, which is outdated.
+import importlib
+jinja_mods = [m for m in sys.modules.keys() if m.startswith('jinja2')]
+for m in jinja_mods:
+    logger.log('unloading {}'.format(m))
+    del sys.modules[m]
+
+from ..vendor.jinja2 import Template
+
+for m in jinja_mods:
+    if m not in sys.modules:
+        logger.log('reloading {}'.format(m))
+        try:
+            importlib.import_module(m)
+        except ImportError:
+            logger.log('could not load {}'.format(m))
 
 
 __all__ = [

--- a/lib/handlers.py
+++ b/lib/handlers.py
@@ -9,7 +9,7 @@ import os
 from http.client import CannotSendRequest
 
 # Use the vendored version explicitly in case the user has an older version
-# of jinja2 in his environment (See: http://bit.ly/2Ozn2QB)
+# of jinja2 in his environment e.g. GitGutter uses v2.8, which is outdated.
 rm_mods = [m for m in sys.modules.keys() if m.startswith('jinja2')]
 for m in rm_mods:
     del sys.modules[m]

--- a/lib/handlers.py
+++ b/lib/handlers.py
@@ -10,6 +10,9 @@ from http.client import CannotSendRequest
 
 # Use the vendored version explicitly in case the user has an older version
 # of jinja2 in his environment (See: http://bit.ly/2Ozn2QB)
+rm_mods = [m for m in sys.modules.keys() if m.startswith('jinja2')]
+for m in rm_mods:
+    del sys.modules[m]
 from ..vendor.jinja2 import Template
 
 from os.path import realpath

--- a/setup/__init__.py
+++ b/setup/__init__.py
@@ -38,7 +38,7 @@ def _setup_path():
             break
 
     if idx != -1:
-        sys.path.insert(os.path.join(_ROOT, 'vendor'), idx)
+        sys.path.insert(idx, os.path.join(_ROOT, 'vendor'))
     else:
         sys.path.append(os.path.join(_ROOT, 'vendor'))
 

--- a/setup/__init__.py
+++ b/setup/__init__.py
@@ -28,7 +28,19 @@ def os_version():
 def _setup_path():
     global _ROOT
     _ROOT = os.path.dirname(os.path.dirname(os.path.realpath(__file__)))
-    sys.path.append(os.path.join(_ROOT, 'vendor'))
+
+    # Determine if python-jinja2 package exists. If so, we need to modify the
+    # path such that we get precedence.
+    idx = -1
+    for i, p in enumerate(sys.path):
+        if '/python-jinja2' in p:
+            idx = i
+            break
+
+    if idx != -1:
+        sys.path.insert(os.path.join(_ROOT, 'vendor'), idx)
+    else:
+        sys.path.append(os.path.join(_ROOT, 'vendor'))
 
 def _setup_os_version():
     global _OS_VERSION


### PR DESCRIPTION
Forces the package to use the vendored version of `jinja2` to prevent outdated versions from being used. (e.g. [GitGutter](https://github.com/jisaacks/GitGutter) uses v2.8, which doesn't have support for `with` tags)