### PR TITLE
Fix escape keybinding

### DIFF
--- a/Default.sublime-keymap
+++ b/Default.sublime-keymap
@@ -13,7 +13,12 @@
   },
   {
     "keys": ["escape"],
-    "command": "kite_hide_signatures"
+    "command": "kite_hide_signatures",
+    "context": [
+      {
+        "key": "kite_signature_shown"
+      }
+    ]
   },
   {
     "keys": ["ctrl+alt+y"],

--- a/lib/handlers.py
+++ b/lib/handlers.py
@@ -356,8 +356,7 @@ class SignaturesHandler(sublime_plugin.EventListener):
                 view.show_popup(content,
                                 flags=sublime.COOPERATE_WITH_AUTO_COMPLETE,
                                 max_width=400,
-                                on_navigate=cls._handle_link_click,
-                                on_hide=lambda: cls._deactivate())
+                                on_navigate=cls._handle_link_click)
 
     @classmethod
     def _render(cls, call):
@@ -392,8 +391,7 @@ class SignaturesHandler(sublime_plugin.EventListener):
             cls._view.show_popup(content,
                                  flags=sublime.COOPERATE_WITH_AUTO_COMPLETE,
                                  max_width=400,
-                                 on_navigate=cls._handle_link_click,
-                                 on_hide=lambda: cls._deactivate())
+                                 on_navigate=cls._handle_link_click)
 
     @classmethod
     def _handle_link_click(cls, target):
@@ -427,10 +425,6 @@ class SignaturesHandler(sublime_plugin.EventListener):
                 link_opener.open_browser(ident)
             else:
                 link_opener.open_copilot(ident)
-
-    @classmethod
-    def _deactivate(cls):
-        cls._activated = False
 
     @classmethod
     def _kwarg_highlighted(cls):

--- a/lib/handlers.py
+++ b/lib/handlers.py
@@ -269,6 +269,11 @@ class SignaturesHandler(sublime_plugin.EventListener):
                             'kite_toggle_keyword_arguments'):
             self.__class__._rerender()
 
+    def on_query_context(self, view, key, operator, operand, match_all):
+        if _is_view_supported(view) and  self.__class__._activated:
+            return True
+        return None
+
     @classmethod
     def queue_signatures(cls, view, location):
         deferred.defer(cls._request_signatures,
@@ -351,7 +356,8 @@ class SignaturesHandler(sublime_plugin.EventListener):
                 view.show_popup(content,
                                 flags=sublime.COOPERATE_WITH_AUTO_COMPLETE,
                                 max_width=400,
-                                on_navigate=cls._handle_link_click)
+                                on_navigate=cls._handle_link_click,
+                                on_hide=lambda: cls._deactivate())
 
     @classmethod
     def _render(cls, call):
@@ -386,7 +392,8 @@ class SignaturesHandler(sublime_plugin.EventListener):
             cls._view.show_popup(content,
                                  flags=sublime.COOPERATE_WITH_AUTO_COMPLETE,
                                  max_width=400,
-                                 on_navigate=cls._handle_link_click)
+                                 on_navigate=cls._handle_link_click,
+                                 on_hide=lambda: cls._deactivate())
 
     @classmethod
     def _handle_link_click(cls, target):
@@ -420,6 +427,10 @@ class SignaturesHandler(sublime_plugin.EventListener):
                 link_opener.open_browser(ident)
             else:
                 link_opener.open_copilot(ident)
+
+    @classmethod
+    def _deactivate(cls):
+        cls._activated = False
 
     @classmethod
     def _kwarg_highlighted(cls):

--- a/lib/handlers.py
+++ b/lib/handlers.py
@@ -270,7 +270,8 @@ class SignaturesHandler(sublime_plugin.EventListener):
             self.__class__._rerender()
 
     def on_query_context(self, view, key, operator, operand, match_all):
-        if _is_view_supported(view) and self.__class__._activated:
+        if (key == 'kite_signature_shown' and _is_view_supported(view) and
+            self.__class__._activated):
             return True
         return None
 

--- a/lib/handlers.py
+++ b/lib/handlers.py
@@ -270,7 +270,7 @@ class SignaturesHandler(sublime_plugin.EventListener):
             self.__class__._rerender()
 
     def on_query_context(self, view, key, operator, operand, match_all):
-        if _is_view_supported(view) and  self.__class__._activated:
+        if _is_view_supported(view) and self.__class__._activated:
             return True
         return None
 

--- a/lib/keymap.py
+++ b/lib/keymap.py
@@ -1,6 +1,7 @@
 import sublime
 
 import json
+import re
 import sys
 
 from ..lib.reporter import send_rollbar_exc
@@ -16,7 +17,11 @@ def get(command):
 def _init_keymap():
     global _KEYMAP
     try:
-        data = json.loads(sublime.load_resource(_PATH))
+        # Remove C-style comments from the `.sublime-keymap` file
+        contents = sublime.load_resource(_PATH)
+        contents = re.sub(r'\\\n', '', contents)
+        contents = re.sub(r'//.*\n', '\n', contents)
+        data = json.loads(contents)
         _KEYMAP = {item['command']: item['keys'] for item in data}
     except ValueError:
         send_rollbar_exc(sys.exc_info())


### PR DESCRIPTION
* Fixes #10 by triggering the `kite_hide_signatures` command in the appropriate contexts only (also fixes kiteco/plugins#114)
* Handles C-style comments in the `.sublime-keymap` file