### PR TITLE
Completions, signatures and settings

### DIFF
--- a/KiteSublime.sublime-settings
+++ b/KiteSublime.sublime-settings
@@ -2,21 +2,26 @@
 // make to this file will be lost when this happens. It's recommended that you change settings in
 // the user settings file in `Packages/User/KiteSublime.package-settings`.
 {
-  // Show the help dialog on startup
+  // Show the help dialog on startup.
   "show_help_dialog": true,
 
-  // Show the hover popup when the mouse hovers over a symbol
+  // Show the hover popup when the mouse hovers over a symbol.
   "show_hover": true,
 
-  // Show function signatures automatically when editing a function call
+  // Show function signatures automatically when editing a function call.
   "show_function_signatures": true,
 
-  // Show inferred keyword arguments when displaying the function signature panel
+  // Show inferred keyword arguments when displaying the function signature panel.
   "show_keyword_arguments": false,
 
-  // Show popular patterns for calling functions when displaying the function signature panel
+  // Show popular patterns for calling functions when displaying the function signature panel.
   "show_popular_patterns": true,
 
-  // Enable verbose logging in the console
+  // Period of time in milliseconds to wait before timing out requests to the Kite Engine.
+  // Setting this value too high may cause Kite's features to appear laggy while setting this
+  // value too low may cause Kite's features to never show up. Default value is 200ms.
+  "engine_timeout": 200,
+
+  // Enable verbose logging in the console.
   "verbose_logs": false
 }

--- a/KiteSublime.sublime-settings
+++ b/KiteSublime.sublime-settings
@@ -18,8 +18,8 @@
   "show_popular_patterns": true,
 
   // Period of time in milliseconds to wait before timing out requests to the Kite Engine.
-  // Setting this value too high may cause Kite's features to appear laggy while setting this
-  // value too low may cause Kite's features to never show up. Default value is 200ms.
+  // Setting this value too high may cause Kite's features to appear laggy. Conversely, setting
+  // this value too low may cause Kite's features to never show up. Default value is 200ms.
   "engine_timeout": 200,
 
   // Enable verbose logging in the console.

--- a/lib/handlers.py
+++ b/lib/handlers.py
@@ -360,7 +360,10 @@ class SignaturesHandler(sublime_plugin.EventListener):
                 content = cls._render(call)
                 cls._lock.release()
 
-            if content is not None:
+            requested_pos = data['cursor_runes']
+            current_pos = EventDispatcher._last_selection_region['end']
+
+            if content is not None and requested_pos == current_pos:
                 view.show_popup(content,
                                 flags=sublime.COOPERATE_WITH_AUTO_COMPLETE,
                                 max_width=400,

--- a/lib/handlers.py
+++ b/lib/handlers.py
@@ -197,8 +197,6 @@ class CompletionsHandler(sublime_plugin.EventListener):
                     (self._brand_completion(c['display'], c['hint']),
                      c['insert']) for c in cls._received_completions
                 ]
-            items = [c['display'] for c in cls._received_completions]
-            logger.log('showing completions: {}'.format(items))
             cls._received_completions = []
             cls._last_location = None
             return completions
@@ -225,8 +223,6 @@ class CompletionsHandler(sublime_plugin.EventListener):
         resp_data = json.loads(body.decode('utf-8'))
         completions = resp_data['completions'] or []
         with cls._lock:
-            items = [c['display'] for c in completions]
-            logger.log('received completions: {}'.format(items))
             cls._received_completions = completions
             cls._last_location = data['cursor_runes']
         cls._run_auto_complete(view)

--- a/lib/requests.py
+++ b/lib/requests.py
@@ -1,8 +1,9 @@
 import json
 import random
+import socket
 from http.client import CannotSendRequest, HTTPConnection
-from socket import timeout
 
+from ..lib import settings
 from ..lib.errors import ExpectedError
 
 _KITED_HOST = 'localhost'
@@ -10,7 +11,7 @@ _KITED_PORT = 46624
 _conns = [None]*4
 
 _IGNORE_EXCEPTIONS = (
-    timeout,
+    socket.timeout,
 )
 
 _RESET_EXCEPTIONS = (
@@ -69,7 +70,16 @@ def _get_connection():
 
 def _init_connection(idx):
     global _conns
-    _conns[idx] = HTTPConnection(_KITED_HOST, port=_KITED_PORT, timeout=0.1)
+
+    timeout = settings.get('engine_timeout', 200)
+    try:
+        timeout = float(timeout) / 1000
+    except ValueError:
+        timeout = 0.2
+
+    _conns[idx] = HTTPConnection(_KITED_HOST,
+                                 port=_KITED_PORT,
+                                 timeout=timeout)
 
 
 def _reset_connection(idx):


### PR DESCRIPTION
* Refreshes the completions list properly
* Stops signature panel from being shown if current cursor position does not match requested position
* Lets user explicitly set the timeout to `kited`