### PR TITLE
Fix Kite Engine startup logic

### DIFF
--- a/KiteSublime.py
+++ b/KiteSublime.py
@@ -1,6 +1,4 @@
-from .setup import setup_all;
-
-setup_all()
+from .setup import setup_all; setup_all()
 
 import sublime
 

--- a/KiteSublime.py
+++ b/KiteSublime.py
@@ -1,4 +1,6 @@
-from .setup import setup_all; setup_all()
+from .setup import setup_all;
+
+setup_all()
 
 import sublime
 
@@ -10,6 +12,7 @@ if int(sublime.version()[0]) < 3:
     raise ImportError('unsupported Sublime: {}'.format(sublime.version()))
 
 import sys
+
 if sys.platform not in ('darwin', 'win32'):
     sublime.error_message(
         'Package KiteSublime is not supported on your OS.\n\n' +
@@ -37,7 +40,8 @@ def plugin_loaded():
     _consumer = deferred.consume()
 
     app_controller.locate_kite()
-    if app_controller.is_kite_installed():
+    if (app_controller.is_kite_installed() and
+            not app_controller.is_kite_running()):
         app_controller.launch_kite()
 
     if settings.get('show_help_dialog', True):

--- a/lib/app_controller.py
+++ b/lib/app_controller.py
@@ -30,3 +30,7 @@ def launch_kite():
 def locate_kite():
     global _KITE_INSTALLED, _KITE_APP
     _KITE_INSTALLED, _KITE_APP = _locate_kite()
+
+
+def is_kite_running():
+    return _is_kite_running()

--- a/lib/platform/darwin/app_controller.py
+++ b/lib/platform/darwin/app_controller.py
@@ -3,13 +3,15 @@ import sys
 
 from ....lib import reporter
 
-__all__ = ['_launch_kite', '_locate_kite']
+__all__ = ['_launch_kite', '_locate_kite', '_is_kite_running']
+
 
 def _launch_kite(app):
     subprocess.check_output(['defaults', 'write', 'com.kite.Kite',
                              'shouldReopenSidebar', '0'])
     proc = subprocess.Popen(['open', '-a', app, '--args', '"--plugin-launch"'])
     return proc
+
 
 def _locate_kite():
     installed = False
@@ -27,3 +29,9 @@ def _locate_kite():
         app = None
     finally:
         return (installed, app)
+
+
+def _is_kite_running():
+    out = subprocess.check_output(['ps', '-axco', 'command'])
+    procs = out.decode('utf-8', 'replace').strip().split('\n') if out else []
+    return 'Kite' in procs

--- a/lib/platform/unsupported/app_controller.py
+++ b/lib/platform/unsupported/app_controller.py
@@ -1,7 +1,13 @@
-__all__ = ['_launch_kite', '_locate_kite']
+__all__ = ['_launch_kite', '_locate_kite', '_is_kite_running']
+
 
 def _launch_kite(app):
     pass
 
+
 def _locate_kite():
     return False, None
+
+
+def _is_kite_running():
+    return False

--- a/lib/platform/win32/app_controller.py
+++ b/lib/platform/win32/app_controller.py
@@ -3,13 +3,16 @@ import sys
 
 from ....lib import reporter
 
-__all__ = ['_launch_kite', '_locate_kite']
+__all__ = ['_launch_kite', '_locate_kite', '_is_kite_running']
 
-_QUERY = 'reg query "HKEY_LOCAL_MACHINE\\Software\\Kite\\AppData" /v InstallPath /s /reg:64'
+_QUERY = 'reg query "HKEY_LOCAL_MACHINE\\Software\\Kite\\AppData" /v ' \
+         'InstallPath /s /reg:64 '
+
 
 def _launch_kite(app):
     proc = subprocess.Popen([app])
     return proc
+
 
 def _locate_kite():
     installed = False
@@ -27,3 +30,19 @@ def _locate_kite():
         app = None
     finally:
         return (installed, app)
+
+
+def _is_kite_running():
+    running = False
+
+    try:
+        out = subprocess.check_output(['tasklist', '/FI', '"IMAGENAME', 'eq',
+                                       'kited.exe'])
+        if len(out) > 0:
+            res = out.decode('utf-8', 'replace')
+            running = 'kited.exe' in res
+    except (subprocess.CalledProcessError, UnicodeDecodeError) as ex:
+        reporter.send_rollbar_exc(sys.exc_info())
+        return running
+    finally:
+        return running


### PR DESCRIPTION
Don't try to run Kite Engine if it's already running on editor startup. This prevents the Copilot window from being shown again.