### PR TITLE
Misc compatibility fixes

### DIFF
--- a/KiteSublime.sublime-settings
+++ b/KiteSublime.sublime-settings
@@ -23,9 +23,13 @@
   // Show function signature snippet completions.
   "show_function_signature_snippet_completions": true,
 
+  // For users of Vintage, this setting controls whether or not hiding
+  // signatures with escape will also cause the editor to enter command mode.
+  "hide_signatures_enters_command_mode": true,
+
   // Period of time in milliseconds to wait before timing out requests to the
   // Kite Engine. Setting this value too high may cause Kite's features to
-  // appear laggy. Conversely, setting this value too low may cause Kite's 
+  // appear laggy. Conversely, setting this value too low may cause Kite's
   // features to never show up. Default value is 200ms.
   "engine_timeout": 200,
 

--- a/lib/handlers.py
+++ b/lib/handlers.py
@@ -372,6 +372,16 @@ class SignaturesHandler(sublime_plugin.EventListener):
     def on_query_context(self, view, key, operator, operand, match_all):
         if (key == 'kite_signature_shown' and _is_view_supported(view) and
                 self.__class__._activated):
+            # In case Vintage is enabled, make sure we switch to command mode.
+            # Questionable if this is the right behavior, since it differs
+            # from the builtin behavior with respect to what happens when the
+            # user hits escape while completions are shown - In this case, the
+            # user still has to hit escape twice to enter command mode. However,
+            # since we've received feedback about this, we've enabled this
+            # behavior and have made it configurable.
+            if settings.get('hide_signatures_enters_command_mode', True):
+                view.run_command('exit_insert_mode')
+
             return True
         return None
 

--- a/lib/handlers.py
+++ b/lib/handlers.py
@@ -54,8 +54,12 @@ def _check_view_size(view):
 
 
 def _in_function_call(view, point):
-    return (view.match_selector(point, 'meta.function-call.python') and
-            not view.match_selector(point, 'variable.function.python'))
+    # The first matched scope is for 3176, and the second is for 3200. Both
+    # are checked here as a hacky fix to account for changes in the API. We
+    # should instead factor version handling logic into a separate module.
+    return ((view.match_selector(point, 'meta.function-call.python') or
+             view.match_selector(point, 'meta.function-call.arguments.python'))
+            and not view.match_selector(point, 'variable.function.python'))
 
 
 def _at_function_call_begin(view, point):

--- a/lib/reporter.py
+++ b/lib/reporter.py
@@ -24,6 +24,7 @@ _ROLLBAR_TOKENS = {
 def send_rollbar_msg(msg):
     if not _ROLLBAR_IS_INIT:
         _init_rollbar()
+
     rollbar.report_message(msg, extra_data={
         'sublime_version': sublime.version(),
         'package_version': package_version(),
@@ -33,6 +34,7 @@ def send_rollbar_msg(msg):
 def send_rollbar_exc(exc):
     if not _ROLLBAR_IS_INIT:
         _init_rollbar()
+
     rollbar.report_exc_info(exc, extra_data={
         'sublime_version': sublime.version(),
         'package_version': package_version(),
@@ -42,6 +44,7 @@ def send_rollbar_exc(exc):
 def setup_excepthook():
     global _MODULE_NAME, _excepthook
     _MODULE_NAME = __name__.split('.')[0]
+
     if _excepthook is None:
         _excepthook = sys.excepthook
         sys.excepthook = _handle_exc
@@ -50,6 +53,7 @@ def setup_excepthook():
 def release_excepthook():
     global _MODULE_NAME, _excepthook
     _MODULE_NAME = None
+
     if _excepthook is not None:
         sys.excepthook = _excepthook
         _excepthook = None
@@ -58,14 +62,18 @@ def release_excepthook():
 def _handle_exc(exctype, value, tb):
     exc = (exctype, value, tb)
     ss = traceback.extract_tb(tb)
-    if is_same_package(ss[-1][0]):
+
+    if len(ss) > 0 and is_same_package(ss[-1][0]):
         sublime.set_timeout_async(lambda: send_rollbar_exc(exc), 0)
+
     _excepthook(exctype, value, tb)
 
 
 def _init_rollbar():
     global _ROLLBAR_IS_INIT
+
     token = (_ROLLBAR_TOKENS['prod'] if not is_development()
              else _ROLLBAR_TOKENS['dev'])
+
     rollbar.init(token)
     _ROLLBAR_IS_INIT = True


### PR DESCRIPTION
* Fixes function call detection for build `3200`
* Fixes kiteco/kiteco#7516 - allows escape key to hide function signature and enter command mode at the same time
* Ignores Rollbar reporting for errors that happen in the console