### PR TITLE
Added fix to Win32 version selection and future string pattern matching problem between different languages

### DIFF
--- a/setup/__init__.py
+++ b/setup/__init__.py
@@ -6,6 +6,7 @@ import platform
 import subprocess
 import sys
 from shutil import copyfile
+from re import findall
 
 _ROOT = None
 _DEVELOPMENT = False
@@ -79,9 +80,9 @@ def _setup_os_version():
         _OS_VERSION = ver[0]
 
     elif sys.platform == 'win32':
-        out = subprocess.check_output('ver', shell=True).decode().strip()
-        out = out.lower()
-        release = out[(out.find('[version ') + 9):-1]
+        out = str(subprocess.check_output('ver', shell=True).strip())
+        pattern = r'(?<=\s)\d+.*(?=\])'
+        release = findall(pattern, out)[0]
         parts = [0] * 4
         for i, n in enumerate(release.split('.')):
             parts[i] = int(n)


### PR DESCRIPTION
Hey! Found 2 little bugs and would like to share them with you. They weren't letting me install the plugin. If this is not the right place, please let me know.

**OS Version**: Microsoft Windows [versão 10.0.16299.1087]

**Problem 1:** Can't decode OS Version during the subprocess.check_output call correctly when using PT-BR language.

Traceback: 

Traceback (most recent call last):
  File "C:\Program Files\Sublime Text 3\sublime_plugin.py", line 125, in reload_plugin
    m = importlib.import_module(modulename)
  File "./python3.3/importlib/__init__.py", line 90, in import_module
  File "<frozen importlib._bootstrap>", line 1584, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1565, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1532, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 584, in _check_name_wrapper
  File "<frozen importlib._bootstrap>", line 1022, in load_module
  File "<frozen importlib._bootstrap>", line 1003, in load_module
  File "<frozen importlib._bootstrap>", line 560, in module_for_loader_wrapper
  File "<frozen importlib._bootstrap>", line 868, in _load_module
  File "<frozen importlib._bootstrap>", line 313, in _call_with_frames_removed
  File "C:\Users\jeansouza\AppData\Roaming\Sublime Text 3\Packages\KiteSublime\KiteSublime.py", line 1, in <module>
    from .setup import *; setup_all()
  File "C:\Users\jeansouza\AppData\Roaming\Sublime Text 3\Packages\KiteSublime\setup\__init__.py", line 20, in setup_all
    _setup_os_version()
  File "C:\Users\jeansouza\AppData\Roaming\Sublime Text 3\Packages\KiteSublime\setup\__init__.py", line 82, in _setup_os_version
    out = subprocess.check_output('ver', shell=True).decode().strip()
UnicodeDecodeError: 'utf-8' codec can't decode byte 0xc6 in position 25: invalid continuation byte

**Problem 2:** Even if it was possible to decode the output of subprocess.check_output in PT_BR and iso-8859-1 encoding properly without much effort, we still wouldn't be able to match the OS Release due to a string match call looking for '[version ', when our output would be '[versão ' 

Traceback (most recent call last):
  File "C:\Program Files\Sublime Text 3\sublime_plugin.py", line 125, in reload_plugin
    m = importlib.import_module(modulename)
  File "./python3.3/importlib/__init__.py", line 90, in import_module
  File "<frozen importlib._bootstrap>", line 1584, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1565, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1532, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 584, in _check_name_wrapper
  File "<frozen importlib._bootstrap>", line 1022, in load_module
  File "<frozen importlib._bootstrap>", line 1003, in load_module
  File "<frozen importlib._bootstrap>", line 560, in module_for_loader_wrapper
  File "<frozen importlib._bootstrap>", line 868, in _load_module
  File "<frozen importlib._bootstrap>", line 313, in _call_with_frames_removed
  File "C:\Users\jeansouza\AppData\Roaming\Sublime Text 3\Packages\KiteSublime\KiteSublime.py", line 1, in <module>
    from .setup import *; setup_all()
  File "C:\Users\jeansouza\AppData\Roaming\Sublime Text 3\Packages\KiteSublime\setup\__init__.py", line 20, in setup_all
    _setup_os_version()
  File "C:\Users\jeansouza\AppData\Roaming\Sublime Text 3\Packages\KiteSublime\setup\__init__.py", line 89, in _setup_os_version
    parts[i] = int(n)
ValueError: invalid literal for int() with base 10: 't Windows [versao 10'

**Fix:** 
I propose a solution based on a more generic regex to get the OS release and also bypassing the decoding part of the process as well. It's a small fix, but should be enough to get things going. If you need anything else, please let me know.

Any kind of review is much appreciated.

Thank you for this awesome piece of art! 