### PR TITLE
Start Kite Engine

### DIFF
--- a/KiteSublime.py
+++ b/KiteSublime.py
@@ -40,9 +40,10 @@ def plugin_loaded():
     setup_completion_rules()
 
     app_controller.locate_kite()
-    if (app_controller.is_kite_installed() and
-            not app_controller.is_kite_running()):
-        app_controller.launch_kite()
+
+    if (settings.get('start_kite_engine_on_startup', True) and
+            app_controller.is_kite_installed()):
+        app_controller.launch_kite_if_not_running()
 
     if settings.get('show_help_dialog', True):
         toggle_dialog = onboarding.start_onboarding()

--- a/KiteSublime.sublime-commands
+++ b/KiteSublime.sublime-commands
@@ -16,6 +16,10 @@
     "command": "kite_open_copilot"
   },
   {
+    "caption": "Kite: Start Engine",
+    "command": "kite_start_engine"
+  },
+  {
     "caption": "Kite: Engine Settings",
     "command": "kite_engine_settings"
   },

--- a/KiteSublime.sublime-settings
+++ b/KiteSublime.sublime-settings
@@ -3,6 +3,9 @@
 // happens. It's recommended that you change settings in the user settings
 // file in `Packages/User/KiteSublime.package-settings`.
 {
+  // Start the Kite Engine on startup.
+  "start_kite_engine_on_startup": true,
+
   // Show the help dialog on startup.
   "show_help_dialog": true,
 

--- a/lib/app_controller.py
+++ b/lib/app_controller.py
@@ -29,6 +29,11 @@ def launch_kite():
     _launch_kite(_KITE_APP)
 
 
+def launch_kite_if_not_running():
+    if not is_kite_running():
+        _launch_kite(_KITE_APP)
+
+
 def locate_kite():
     global _KITE_INSTALLED, _KITE_APP
     _KITE_INSTALLED, _KITE_APP = _locate_kite()

--- a/lib/commands.py
+++ b/lib/commands.py
@@ -1,7 +1,7 @@
 import sublime
 import sublime_plugin
 
-from ..lib import link_opener, logger, onboarding, settings
+from ..lib import app_controller, link_opener, logger, onboarding, settings
 from ..lib.handlers import HoverHandler, SignaturesHandler
 
 
@@ -95,6 +95,26 @@ class KiteOpenCopilot(sublime_plugin.ApplicationCommand):
 
     def run(self):
         link_opener.open_copilot_root('')
+
+
+class KiteStartEngine(sublime_plugin.ApplicationCommand):
+    """Command to start the Kite Engine.
+    """
+
+    def run(self):
+        if not app_controller.is_kite_installed():
+            if sublime.ok_cancel_dialog(
+                'Kite Engine is not installed. You can install it at ' \
+                'https://kite.com/download.',
+                ok_title='Download'
+            ):
+                link_opener.open_browser_url('https://kite.com/download')
+
+        elif app_controller.is_kite_running():
+            sublime.message_dialog('Kite Engine is already running!')
+
+        else:
+            app_controller.launch_kite_if_not_running()
 
 
 class KiteEngineSettings(sublime_plugin.ApplicationCommand):


### PR DESCRIPTION
* Allows user to configure whether or not to start Kite Engine on editor startup
* Adds the command `Kite: Start Engine` to allow the user to start Kite Engine manually from Sublime