### PR TITLE
No hover for gutter and trailing whitespace

### DIFF
--- a/lib/handlers.py
+++ b/lib/handlers.py
@@ -521,6 +521,9 @@ class HoverHandler(sublime_plugin.EventListener):
         if not settings.get('show_hover', True):
             return
 
+        if hover_zone != sublime.HOVER_TEXT:
+            return
+
         if (_is_view_supported(view) and _check_view_size(view) and
                 len(view.sel()) == 1):
             cls = self.__class__


### PR DESCRIPTION
Only show a hover panel when the user is hovering on text content.
A hover on the gutter and on trailing whitespace isn't useful.

Tested with SublimeLinter-flake8 on Linux. The gutter message of the flake8 plugin are shown as expected.

See https://www.sublimetext.com/docs/3/api_reference.html#sublime_plugin.EventListener for the SDK docs

Closes #46 
Closes https://github.com/kiteco/kiteco/issues/8155