### PR TITLE
Only hide popups which were (most probably) created by the Kite plugin.

### DIFF
--- a/lib/handlers.py
+++ b/lib/handlers.py
@@ -339,10 +339,11 @@ class SignaturesHandler(sublime_plugin.EventListener):
     def hide_signatures(cls, view):
         reset = False
         if cls._lock.acquire(blocking=False):
-            cls._activated = False
-            cls._view = None
-            cls._call = None
-            reset = True
+            if cls._activated:
+                cls._activated = False
+                cls._view = None
+                cls._call = None
+                reset = True
             cls._lock.release()
 
         if reset:


### PR DESCRIPTION
We must not hide popups which are managed by other Sublime plugins.
Closes https://github.com/kiteco/KiteSublime/issues/50