### PR TITLE
Limit file size to 75 kb

### DIFF
--- a/lib/handlers.py
+++ b/lib/handlers.py
@@ -51,7 +51,8 @@ def _is_view_supported(view):
 
 
 def _check_view_size(view):
-    return view.size() <= (1 << 20)
+    # max file size is 75 kilobytes (75 * 1024)
+    return view.size() <= 76800
 
 
 def _in_function_call(view, point):


### PR DESCRIPTION
This PR changes the max file size limit. Sublime is using view.size() which is returning the number of characters in the buffer. This should be okay because we've been using that before and because it's too expensive to check the file size on disk.

Closes https://github.com/kiteco/KiteSublime/issues/49
Closes https://github.com/kiteco/kiteco/issues/8206