### PR TITLE
Find Related Code (experimental)

### DIFF
--- a/KiteSublime.sublime-commands
+++ b/KiteSublime.sublime-commands
@@ -32,6 +32,14 @@
     }
   },
   {
+    "caption": "Kite: Find Related Code From File (experimental)",
+    "command": "kite_find_related_code_from_file"
+  },
+  {
+    "caption": "Kite: Find Related Code From Line (experimental)",
+    "command": "kite_find_related_code_from_line"
+  },
+  {
     "caption": "Kite: Python Tutorial",
     "command": "kite_python_tutorial"
   },

--- a/lib/codenav.py
+++ b/lib/codenav.py
@@ -1,0 +1,87 @@
+import requests
+import sublime
+from collections import defaultdict
+
+from ..lib import link_opener
+from ..lib import errors
+
+err_to_exception = defaultdict(lambda: errors.GenericRelatedCodeError, {
+    'ErrPathNotInSupportedProject': errors.PathNotInSupportedProjectError,
+    'ErrProjectStillIndexing': errors.ProjectStillIndexingError,
+})
+
+def related_code_from_file(view):
+    related_code(lambda: True, view.file_name(), None)
+
+def related_code_from_line(view):
+    sels = view.sel()
+    start_point = sels[0].begin()
+    zero_based_line_no = view.rowcol(start_point)[0]
+
+    def precond():
+        if len(sels) > 1:
+            raise errors.MultipleSelectionError("", "MultipleSelectionError")
+        if (view.classify(start_point) & sublime.CLASS_EMPTY_LINE) != 0:
+            raise errors.EmptyLineSelectionError("", "EmptyLineSeletionError")
+
+    related_code(precond, view.file_name(), zero_based_line_no+1)
+
+def related_code(precond, filename, line_no):
+    """ Runs a precondition function and then requests related code
+        Catches expected errors and notifies the user
+    """
+    try:
+        precond()
+        request_related_code(filename, line_no)
+    except errors.MultipleSelectionError:
+        sublime.error_message(
+            "Kite Code Finder Error \n\n" +
+            "Navigation only works for a single selection."
+        )
+    except errors.EmptyLineSelectionError:
+        sublime.error_message(
+            "Kite Code Finder Error \n\n" +
+            " ".join(["Line", str(line_no), "in", filename, "is empty. "]) +
+            "Code finder only works on non-empty lines."
+        )
+    except requests.exceptions.RequestException:
+        sublime.error_message(
+            "Kite Code Finder Error \n\n" +
+            "Kite could not be reached. " +
+            "Please check that Kite engine is running."
+        )
+    except errors.PathNotInSupportedProjectError:
+        sublime.error_message(
+            "Kite Code Finder Error \n\n" +
+            " ".join(["The file", filename, "is not in any Git project. "]) +
+            "Code finder only works inside Git projects."
+        )
+    except errors.ProjectStillIndexingError:
+        sublime.error_message(
+            "Kite Code Finder Error \n\n" +
+            "Kite is not done indexing your project yet. " +
+            "Please wait for the status icon to switch to ready before using Code Finder."
+        )
+    except errors.GenericRelatedCodeError:
+        sublime.error_message(
+            "Kite Code Finder Error \n\n" +
+            "Oops! Something went wrong with Code Finder. Please try again later."
+        )
+
+def request_related_code(filename, line_no):
+    """ Attempts to initiate a related code request
+        Raises exceptions from response errors
+    """
+    url = 'http://localhost:46624/codenav/editor/related'
+    resp = requests.post(url, json=
+                {
+                    'editor': 'sublime3',
+                    'location': {
+                        'filename': filename,
+                        'line': line_no
+                    },
+                }
+            )
+    if resp.status_code != 200:
+        exc = resp.content.decode('utf8').strip()
+        raise err_to_exception[exc](exc, exc)

--- a/lib/commands.py
+++ b/lib/commands.py
@@ -1,7 +1,8 @@
 import sublime
 import sublime_plugin
 
-from ..lib import app_controller, link_opener, logger, onboarding, settings
+from ..lib import app_controller, link_opener, logger, settings
+from ..lib import onboarding, codenav
 from ..lib.handlers import HoverHandler, SignaturesHandler
 from ..lib.languages import Languages
 
@@ -168,3 +169,16 @@ class KiteHelp(sublime_plugin.ApplicationCommand):
     def run(self):
         link_opener.open_browser_url(self._URL)
 
+class KiteFindRelatedCodeFromFile(sublime_plugin.WindowCommand):
+    """Command to initiate file-based codenav
+    """
+
+    def run(self):
+        codenav.related_code_from_file(self.window.active_view())
+
+class KiteFindRelatedCodeFromLine(sublime_plugin.WindowCommand):
+    """Command to initiate line-based codenav
+    """
+
+    def run(self):
+        codenav.related_code_from_line(self.window.active_view())

--- a/lib/errors.py
+++ b/lib/errors.py
@@ -4,3 +4,18 @@ class ExpectedError(Exception):
     def __init__(self, exc, message):
         self.exc = exc
         self.message = message
+
+class MultipleSelectionError(ExpectedError):
+    pass
+
+class EmptyLineSelectionError(ExpectedError):
+    pass
+
+class PathNotInSupportedProjectError(ExpectedError):
+    pass
+
+class ProjectStillIndexingError(ExpectedError):
+    pass
+
+class GenericRelatedCodeError(ExpectedError):
+    pass


### PR DESCRIPTION
Addresses https://github.com/kiteco/kiteco/issues/11900 for sublime

### What was done

Added commands "Kite: Related Code from {File | Line} (experimental)". I'm not sure Python best practice for converting the response content error to notifications. Went with exceptions but open to other approaches too.

### Notifications

<img width="427" alt="Screen Shot 2020-11-03 at 4 20 31 PM" src="https://user-images.githubusercontent.com/18232816/98055668-e23ef500-1df2-11eb-9081-e16b19acf67d.png">
<img width="434" alt="Screen Shot 2020-11-03 at 4 16 41 PM" src="https://user-images.githubusercontent.com/18232816/98055670-e408b880-1df2-11eb-8b44-cbe4fe6e0e4f.png">
<img width="430" alt="Screen Shot 2020-11-03 at 4 16 12 PM" src="https://user-images.githubusercontent.com/18232816/98055671-e4a14f00-1df2-11eb-916b-dce99e521921.png">
